### PR TITLE
docs: document ts_keys helper

### DIFF
--- a/src/wecgrid/modelers/power_system/base.py
+++ b/src/wecgrid/modelers/power_system/base.py
@@ -114,6 +114,7 @@ class GridState:
                 └─ time-series: p, q, status
         """
         def ts_keys(d):
+            """Format available time-series keys for display."""
             return ", ".join(d.keys()) if d else "none"
 
         return (


### PR DESCRIPTION
## Summary
- add internal docstring explaining GridState __repr__ time-series key formatter

## Testing
- `pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c86c04ac832196ec3b6c34ed5742