### PR TITLE
Document attribute mapping in AttrDict

### DIFF
--- a/src/wecgrid/modelers/power_system/base.py
+++ b/src/wecgrid/modelers/power_system/base.py
@@ -25,12 +25,18 @@ class AttrDict(dict):
         AttributeError: If the requested attribute/key does not exist.
     """
     def __getattr__(self, name):
+        """Map attribute access to dictionary lookup.
+
+        Raises:
+            AttributeError: If the key is absent.
+        """
         try:
             return self[name]
         except KeyError:
             raise AttributeError(f"'AttrDict' has no attribute '{name}'")
 
     def __setattr__(self, name, value):
+        """Map attribute assignment to setting a dictionary key."""
         self[name] = value
 
 


### PR DESCRIPTION
## Summary
- Clarify how AttrDict handles attribute access and assignment with new docstrings.

## Testing
- `pytest -q` *(fails: No module named 'matlab')*


------
https://chatgpt.com/codex/tasks/task_e_68a7c86034ac832188ebebdb4e1d0cea