### PR TITLE
Add docstring for util module

### DIFF
--- a/src/wecgrid/util/__init__.py
+++ b/src/wecgrid/util/__init__.py
@@ -1,8 +1,9 @@
 # src/wecgrid/util/__init__.py
+"""Collection of utilities, including time management and database helpers."""
 
 from .time import WECGridTime
 from .database import WECGridDB
 
 
 __all__ = ["WECGridTime", "WECGridDB"]
-    
+


### PR DESCRIPTION
## Summary
- add module-level docstring to util package

## Testing
- `pytest` *(fails: No module named 'matlab', 'pssepath', 'pypsa', or 'wecgrid')*


------
https://chatgpt.com/codex/tasks/task_e_68a7ca8e26e483218beb56c2ec25b8be