### PR TITLE
Add module docstring for MATLAB test

### DIFF
--- a/test/test_matlab.py
+++ b/test/test_matlab.py
@@ -1,3 +1,5 @@
+"""Verify MATLAB engine availability."""
+
 def test_matlab():
     """Test MATLAB modules can be imported."""
     import matlab.engine


### PR DESCRIPTION
## Summary
- clarify MATLAB engine availability test with module-level docstring

## Testing
- `pytest` *(fails: No module named 'matlab', 'pssepath', 'pypsa', 'wecgrid')*

------
https://chatgpt.com/codex/tasks/task_e_68a7ca9547008321ade88121b6067b3f