### PR TITLE
Update time import in tests to WECGridTime

### DIFF
--- a/test/test_wecgrid.py
+++ b/test/test_wecgrid.py
@@ -16,10 +16,10 @@ def test_wecgrid_database():
     assert WECGridDB is not None
 
 
-def test_wecgrid_timemanager():
-    """Test time manager can be imported."""
-    from wecgrid.util.time import WECGridTimeManager
-    assert WECGridTimeManager is not None
+def test_wecgrid_time():
+    """Test time module can be imported."""
+    from wecgrid.util.time import WECGridTime
+    assert WECGridTime is not None
 
 
 def test_wecgrid_plot():


### PR DESCRIPTION
## Summary
- replace deprecated WECGridTimeManager import with WECGridTime in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'wecgrid')*

------
https://chatgpt.com/codex/tasks/task_e_68a7f80356d88321b75847b90418861f