### PR TITLE
Skip tests when optional dependencies missing

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -23,3 +23,6 @@ addopts =
 markers =
     pypsa: Tests requiring PyPSA
     wec_sim: Tests requiring WEC-Sim data
+    matlab: Tests requiring MATLAB
+    psse: Tests requiring PSS®E
+

--- a/test/test_matlab.py
+++ b/test/test_matlab.py
@@ -1,7 +1,11 @@
 """Verify MATLAB engine availability."""
 
+import pytest
+
+
+@pytest.mark.matlab
 def test_matlab():
     """Test MATLAB modules can be imported."""
-    import matlab.engine
-    assert matlab.engine is not None
-    
+    engine = pytest.importorskip("matlab.engine")
+    assert engine is not None
+

--- a/test/test_psse.py
+++ b/test/test_psse.py
@@ -1,8 +1,15 @@
+"""Tests for PSS®E integration."""
+
+import pytest
+
+
+@pytest.mark.psse
 def test_psse():
     """Test PSS®E modules can be imported."""
-    import pssepath
+    pssepath = pytest.importorskip("pssepath")
     pssepath.add_pssepath()
-    import psspy
-    import psse35
+    psspy = pytest.importorskip("psspy")
+    psse35 = pytest.importorskip("psse35")
     assert psspy is not None
     assert psse35 is not None
+

--- a/test/test_wecsim.py
+++ b/test/test_wecsim.py
@@ -1,61 +1,73 @@
+"""Tests for WEC-Sim integration."""
+
+import io
+import pytest
+
+
+@pytest.mark.matlab
 def test_matlab():
     """Test MATLAB modules can be imported."""
-    import matlab.engine
-    assert matlab.engine is not None
-    
+    engine = pytest.importorskip("matlab.engine")
+    assert engine is not None
+
+
+@pytest.mark.wec_sim
 def test_wecsim():
     """Test basic WEC-Sim engine initialization."""
-    import wecgrid
+    wecgrid = pytest.importorskip("wecgrid")
+    pytest.importorskip("matlab.engine")
     test = wecgrid.Engine()
     assert test is not None
     test.wecsim.start_matlab()
 
+
+@pytest.mark.wec_sim
 def test_wecsim_run_from_sim():
     """Test WEC-Sim runFromSimTest functionality."""
-    import matlab.engine
-    import wecgrid
-    import io
-    
+    matlab_engine_module = pytest.importorskip("matlab.engine")
+    wecgrid = pytest.importorskip("wecgrid")
+
     # Setup output capture
     out = io.StringIO()
     err = io.StringIO()
-    
+
     # Initialize engines
     engine = wecgrid.Engine()
-    matlab_engine = matlab.engine.start_matlab()
-    
+    matlab_engine = matlab_engine_module.start_matlab()
+
     # Change to WEC-Sim path
     matlab_engine.cd(engine.wecsim.get_wec_sim_path())
-    
+
     # Run the WEC-Sim test
     matlab_engine.eval(
-        "wecSimTest(bemioTest=false, regressionTest=false, compilationTest=true, runFromSimTest=true, rotationTest=false)", 
-        nargout=0, 
-        stdout=out, 
-        stderr=err
+        "wecSimTest(bemioTest=false, regressionTest=false, compilationTest=true, runFromSimTest=true, rotationTest=false)",
+        nargout=0,
+        stdout=out,
+        stderr=err,
     )
-    
+
     # Get the output
     output = out.getvalue()
     error_output = err.getvalue()
-    
+
     # Print output for debugging
     print("STDOUT:", output)
     if error_output:
         print("STDERR:", error_output)
-    
+
     # Assertions to verify the test ran successfully
     assert "Running runFromSimTest" in output
     assert "Done runFromSimTest" in output
     assert "WEC-Sim: An open-source code for simulating wave energy converters" in output
     assert "2 Passed, 0 Failed, 0 Incomplete" in output
-    
+
     # Check that no errors occurred
     assert error_output == "" or "error" not in error_output.lower()
-    
+
     # Verify specific test cases passed
     assert "runFromSimTest/fromSimCustom" in output
     assert "runFromSimTest/fromSimInput" in output
-    
+
     # Clean up
     matlab_engine.quit()
+


### PR DESCRIPTION
## Summary
- ensure MATLAB, PSS®E and WEC-Sim tests skip when optional dependencies are absent
- add explicit `matlab`, `psse`, and `wec_sim` markers

## Testing
- `pytest test/test_matlab.py test/test_psse.py test/test_wecsim.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7f814803883219a45713507296392