### PR TITLE
Refactor packaging to rely on pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "wecgrid"
 version = "0.1.0"
 description = "WEC-Grid: A tool for integrating Wave Energy Converter models into power system simulations"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.7"
 authors = [{name = "Alexander Barajas-Ritchie", email = "barajale@oregonstate.edu"}]
 license = {text = "MIT"}
 dependencies = [
@@ -24,15 +24,28 @@ dependencies = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Energy",
 ]
 
+[project.urls]
+Homepage = "https://github.com/acep-uaf/WEC-GRID"
+
 [tool.setuptools]
 package-dir = {"" = "src"}
+include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+wecgrid = [
+    "util/*.json",
+    "modelers/wec_sim/*.json",
+]
 

--- a/setup.py
+++ b/setup.py
@@ -1,45 +1,4 @@
-from pathlib import Path
-from setuptools import setup, find_packages
+from setuptools import setup
 
-README = Path(__file__).with_name("README.md").read_text(encoding="utf-8")
-
-setup(
-    name="wecgrid",
-    version="0.1.0",
-    author="Alexander Barajas-Ritchie",
-    author_email="barajale@oregonstate.edu",
-    description="WEC-Grid: A tool for integrating Wave Energy Converter models into power system simulations",
-    long_description=README,
-    long_description_content_type="text/markdown",
-    url="https://github.com/acep-uaf/WEC-GRID",
-    license="MIT",
-    package_dir={"": "src"},
-    packages=find_packages(where="src"),
-    include_package_data=True,
-    package_data={
-        "wecgrid": [
-            "util/*.json",
-            "modelers/wec_sim/*.json",
-        ]
-    },
-    install_requires=[
-        "numpy>=1.21",
-        "pandas>=1.3",
-        "matplotlib>=3.4",
-        "seaborn>=0.11",
-        "pypsa",
-        "pypower>=5.1.17",
-        "grg-pssedata",
-        "tqdm>=4.0",
-        "requests>=2.0",
-        "networkx>=2.5",
-    ],
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Intended Audience :: Science/Research",
-        "Topic :: Scientific/Engineering :: Energy",
-    ],
-    python_requires=">=3.7",
-)
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
## Summary
- declare project metadata and dependencies in `pyproject.toml`
- add minimal `setup.py` shim for legacy tooling
- relax Python requirement to 3.7 and expand classifiers

## Testing
- `pip install -e .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'matlab')*

------
https://chatgpt.com/codex/tasks/task_e_68a7f824f9b88321976fee12eefbba04