### PR TITLE
Add optional dependency groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,17 @@ For the current implementations, WEC-Grid is compatible with PSSe and [WEC-SIM](
    ```bash
    conda activate wec_grid_env
    ```
-5. Install WEC-Grid
+5. Install WEC-Grid (includes `grg-pssedata` for PSS\u00aeE RAW parsing)
    ```bash
    pip install -e .
    ```
-6. Run tests
+6. (Optional) Install extra dependencies
+   ```bash
+   pip install wecgrid[psse]    # PSS\u00aeE API support
+   pip install wecgrid[matlab]  # MATLAB engine integration
+   pip install wecgrid[wecsim]  # WEC-Sim interface
+   ```
+7. Run tests
    ```bash
    pytest /test -v
    ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,13 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Energy",
 ]
 
+[project.optional-dependencies]
+psse = [
+    "pssepath",
+]
+matlab = ["matlabengine"]
+wecsim = ["matlabengine"]
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 


### PR DESCRIPTION
## Summary
- move PSSE utilities to optional extras
- expose extras for MATLAB engine and WEC-Sim
- document optional extras in README
- require `grg-pssedata` as a core dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matlab'; ModuleNotFoundError: No module named 'pssepath'; ImportError: cannot import name 'WECGridTimeManager')*

------
https://chatgpt.com/codex/tasks/task_e_68a7f848ce2c8321bffba6ecc818658b